### PR TITLE
Fix iOS double listeners

### DIFF
--- a/.changeset/three-shoes-grab.md
+++ b/.changeset/three-shoes-grab.md
@@ -1,0 +1,5 @@
+---
+"@cactuslab/native-navigation": patch
+---
+
+Address listeners not being removed by ensuring that we only forward to the bridge navigation on the main webview

--- a/packages/plugin/ios/Plugin/NativeNavigationWebViewDelegate.swift
+++ b/packages/plugin/ios/Plugin/NativeNavigationWebViewDelegate.swift
@@ -22,9 +22,10 @@ class NativeNavigationWebViewDelegate : NSObject, WKUIDelegate, WKNavigationDele
     // The force unwrap is part of the protocol declaration, so we should keep it.
     // swiftlint:disable:next implicitly_unwrapped_optional
     public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        self.wrappedNavigationDelegate?.webView?(webView, didStartProvisionalNavigation: navigation)
         
         if webView == mainWebView {
+            self.wrappedNavigationDelegate?.webView?(webView, didStartProvisionalNavigation: navigation)
+            
             /* Whenever there is navigation or a page load in Capacitor's webview we must reset the UI that this plugin has created
                otherwise whatever happens in Capacitor's webview will not be visible as our UI will cover it.
              */


### PR DESCRIPTION
Address listeners not being removed by ensuring that we only forward to the bridge navigation on the main webview